### PR TITLE
Pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,19 @@
 
 ## Installing dependencies for WindowFractalCode.py
 
-1. Create a virtual environment and activate it:
+1. Create a virtual environment and activate it.
 ```
 python3 -m venv /path/to/folder
 cd /path/to/folder
 source bin/activate
 ```
 
-2. Install dependencies using pip:
+2. Upgrade pip.
+```
+pip install --upgrade pip
+```
+
+3. Install dependencies using pip.
 ```
 pip install -r requirements.txt
 ```

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # SlidingWindows
+
+## Installing dependencies for WindowFractalCode.py
+
+1. Create a virtual environment and activate it:
+```
+python3 -m venv /path/to/folder
+cd /path/to/folder
+source bin/activate
+```
+
+2. Install dependencies using pip:
+```
+pip install -r requirements.txt
+```
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,16 @@
+cloudpickle==0.8.0
+cycler==0.10.0
+dask==1.1.2
+decorator==4.3.2
+kiwisolver==1.0.1
+matplotlib==3.0.2
+networkx==2.2
+numpy==1.16.1
+Pillow==5.4.1
+pyparsing==2.3.1
+python-dateutil==2.8.0
+PyWavelets==1.0.2
+scikit-image==0.14.2
+scipy==1.2.1
+six==1.12.0
+toolz==0.9.0


### PR DESCRIPTION
To make future code easier to distribute and behavior more reproducible across different environments, I'm proposing that we switch our dependency management from anaconda to pip. This PR adds the information necessary for pip to install correct versions of libraries we currently use, in particular: Numpy, PIL (pillow), skimage (scikit-image), matplotlib, and their dependencies.